### PR TITLE
add a commit callback to the asyncAdapter

### DIFF
--- a/ti-recycler/src/main/java/ru/tinkoff/mobile/tech/ti_recycler/adapters/AsyncTiAdapter.kt
+++ b/ti-recycler/src/main/java/ru/tinkoff/mobile/tech/ti_recycler/adapters/AsyncTiAdapter.kt
@@ -15,4 +15,8 @@ class AsyncTiAdapter<T : ViewTyped, HF : HolderFactory>(
     override var items: List<T>
         get() = asyncListDiffer.currentList
         set(newItems) = asyncListDiffer.submitList(newItems)
+
+    fun submitItems(items: List<T>, commitCallback: () -> Unit) {
+        asyncListDiffer.submitList(items, commitCallback)
+    }
 }


### PR DESCRIPTION
added a callback that allows a client to take an action just after the asyncDiffer has calculated all the data